### PR TITLE
Added option to override the button text when all items are selected

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -223,7 +223,9 @@
 		update: function() {
 			var selects = this.getSelects('text'),
 				$span = this.$choice.find('>span');
-			if (selects.length) {
+			if(selects.length == this.$selectItems.length && this.options.overrideButtonText) {
+				$span.removeClass('placeholder').html(this.options.selectAllText);
+			} else if (selects.length) {
 				$span.removeClass('placeholder').html(selects.join(', '));
 			} else {
 				$span.addClass('placeholder').html(this.options.placeholder);


### PR DESCRIPTION
This change adds the ability to set the default button text for the case when all items are selected to be equal to the selectAllText option. The type of the overrideButtonText option is a boolean value.
