### PR TITLE
Added fix for firefox bug

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -139,7 +139,8 @@
 
         events: function() {
             var that = this;
-            this.$choice.off('click').on('click', function() {
+            this.$choice.off('click').on('click', function(e) {
+                e.preventDefault();
                 that[that.options.isOpen ? 'close' : 'open']();
             })
                 .off('focus').on('focus', this.options.onFocus)


### PR DESCRIPTION
The dropdown would immediately close after being opened in the latest version of firefox (couldn't replicate on the demo page). Fix doesn't break other browsers and fixes the bug I experienced.
