### PR TITLE
Adding blockSeperator option

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -111,18 +111,28 @@
                     style = this.options.styler(value) ? ' style="' + this.options.styler(value) + '"' : '';
 
                 disabled = groupDisabled || $elm.prop('disabled');
-                html.push(
-                    '<li' + (multiple ? ' class="multiple"' : '') + style + '>',
-                        '<label' + (disabled ? ' class="disabled"' : '') + '>',
-                            '<input type="' + type + '" ' + this.selectItemName + ' value="' + value + '"' +
-                                (selected ? ' checked="checked"' : '') +
-                                (disabled ? ' disabled="disabled"' : '') +
-                                (group ? ' data-group="' + group + '"' : '') +
-                                '/> ',
-                            text,
-                        '</label>',
-                    '</li>'
-                );
+                if ((this.options.blockSeperator>"") && (this.options.blockSeperator==$elm.val())) {
+	                html.push(
+		                    '<li' + (multiple ? ' class="multiple"' : '') + style + '>',
+		                        '<label class="' + this.options.blockSeperator + (disabled ? 'disabled' : '') + '">',
+		                            text,
+		                        '</label>',
+		                    '</li>'
+	                );                	
+                } else {
+	                html.push(
+		                    '<li' + (multiple ? ' class="multiple"' : '') + style + '>',
+		                        '<label' + (disabled ? ' class="disabled"' : '') + '>',
+		                            '<input type="' + type + '" ' + this.selectItemName + ' value="' + value + '"' +
+		                                (selected ? ' checked="checked"' : '') +
+		                                (disabled ? ' disabled="disabled"' : '') +
+		                                (group ? ' data-group="' + group + '"' : '') +
+		                                '/> ',
+		                            text,
+		                        '</label>',
+		                    '</li>'
+	                );
+                }
             } else if (!group && $elm.is('optgroup')) {
                 var _group = 'group_' + i,
                     label = $elm.attr('label');
@@ -457,6 +467,7 @@
         container: null,
         position: 'bottom',
         keepOpen: false,
+        blockSeperator: '',
 
         styler: function() {return false;},
 


### PR DESCRIPTION
First of all - thanks for your script.
I needed for a project (where I sue this script) something similar to the optgroup function - but without the checkbox, just a plain li element to seperate several groups of options. So I added a "blockSeperator" option. Setting this to a string value causes all options elements set to this value to be a plain li element with the CSS class set to the blockSeperator value.
Easily saying: <option value="justAHeadline">Text</option> results (with a blockSeperator set to "justAHeadline") an element <li><label class="JustAHeadline">Text</label></li> instead to a checkbox block.
Maybe you think this is useful ... just wanted to contribute it :)
