### PR TITLE
Trigger the checkbox on the entire line

### DIFF
--- a/multiple-select.css
+++ b/multiple-select.css
@@ -174,6 +174,7 @@
 
 .ms-drop ul > li label {
     font-weight: normal;
+    display: block;
 }
 
 .ms-drop ul > li label.optgroup {


### PR DESCRIPTION
With this you don't have to click only in the text but also on the line of the option, it makes it easier for users and more inlined with the behavior of a select box.
