### PR TITLE
Add a filterAcceptOnEnter option

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -171,7 +171,16 @@
                         break;
                 }
             });
-            this.$searchInput.off('keyup').on('keyup', function() {
+            this.$searchInput.off('keyup').on('keyup', function(e) {
+                if (that.options.filterAcceptOnEnter &&
+                    (e.which === 13 || e.which == 32) && // enter or space
+                    that.$searchInput.val() // Avoid selecting/deselecting if no choices made
+                ) {
+                    that.$selectAll.click();
+                    that.close();
+                    that.focus();
+                    return;
+                }
                 that.filter();
             });
             this.$selectAll.off('click').on('click', function() {


### PR DESCRIPTION
This is another PR which I think can speed up keyboard use. No need to tab to click to "select all"; just hit "space" or "enter" while in the filter box when the "filterAcceptOnEnter" option is enabled and some filtering criteria has been entered.

(If you don't want "space" supported, or if you want to avoid closing the select upon enter when filtering has occurred but no filters have been found, I can submit an adjusted PR.)
