### PR TITLE
Make optgroups' checkboxes optional

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -142,7 +142,7 @@
                 html.push(
                     '<li class="group">',
                         '<label class="optgroup' + (disabled ? ' disabled' : '') + '" data-group="' + _group + '">',
-                            (this.options.hideOptgroups ? '' : '<input type="checkbox" ' + this.selectGroupName +
+                            (this.options.hideOptgroupCheckboxes ? '' : '<input type="checkbox" ' + this.selectGroupName +
                                 (disabled ? ' disabled="disabled"' : '') + ' /> '),
                             label,
                         '</label>',


### PR DESCRIPTION
Optgroup checkboxes may not be desirable when the grouping is only conceptual and not meant for all choices to be made at once.
