### PR TITLE
INPUT tags should be nameless

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -51,9 +51,9 @@
             });
         }
 
-        this.selectAllName = 'name="selectAll' + name + '"';
-        this.selectGroupName = 'name="selectGroup' + name + '"';
-        this.selectItemName = 'name="selectItem' + name + '"';
+        this.selectAllName = 'data-name="selectAll' + name + '"';
+        this.selectGroupName = 'data-name="selectGroup' + name + '"';
+        this.selectItemName = 'data-name="selectItem' + name + '"';
     }
 
     MultipleSelect.prototype = {


### PR DESCRIPTION
Having nameless INPUT tags means they won't be included in any form submission. Currently form submissions are being contaminated with the the extra checkboxes added by the plugin.