### PR TITLE
Current selected element not displayed in newer jquery versions

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -124,7 +124,7 @@
             if ($elm.is('option')) {
                 var value = $elm.val(),
                     text = that.options.textTemplate($elm),
-                    selected = (that.$el.attr('multiple') != undefined) ? $elm.prop('selected') : ($elm.attr('selected') == 'selected'),
+                    selected = $elm.prop('selected'),
                     style = this.options.styler(value) ? ' style="' + this.options.styler(value) + '"' : '';
 
                 disabled = groupDisabled || $elm.prop('disabled');


### PR DESCRIPTION
... without jquery.migrate.
It's because it's using `that.$el.attr("selected") == "selected"` on single selects.
I have changed that to `$elm.prop('selected')` (same as on multi selects) and it works fine for me but I don't know why it was explicitly using another element variable and the `attr()` function for `selected`.