### PR TITLE
Fixed filter functionality with 'no-results' label behavior

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -478,7 +478,7 @@
                 });
 
                 //Check if no matches found
-                if (this.$selectItems.filter(':visible').length) {
+                if (this.$selectItems.parent().filter(':visible').length) {
                     this.$selectAll.parent().show();
                     this.$noResults.hide();
                 } else {


### PR DESCRIPTION
Hi! 
If we're hide select item's parent (list-item) on searching/filtering, then it could be a good idea filter list-items instead of filtering selectItems itself. Isn't it? 😃