### PR TITLE
Pass Multiple Select object with event callbacks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1252,6 +1252,18 @@ onClick: function(view) {
 }
 ```
 
+#### onAfterCreate
+
+Fires after the Multiple Select is created
+
+```javascript
+onAfterCreate: function(select) {
+	/*
+	select: the Multiple Select object
+	*/
+}
+```
+
 ### Methods
 
 #### getSelects

--- a/docs/README.md
+++ b/docs/README.md
@@ -1012,32 +1012,32 @@ If you're dynamically adding/removing option tags on the original select via AJA
     <script src="jquery.multiple.select.js"></script>
     <script>
         $("select").multipleSelect({
-        	onOpen: function() {
+        	onOpen: function(select) {
         		$eventResult.text('Select opened!');
         	},
-        	onClose: function() {
+        	onClose: function(select) {
         		$eventResult.text('Select closed!');
         	},
-        	onCheckAll: function() {
+        	onCheckAll: function(select) {
         		$eventResult.text('Check all clicked!');
         	},
-        	onUncheckAll: function() {
+        	onUncheckAll: function(select) {
         		$eventResult.text('Uncheck all clicked!');
         	},
-        	onFocus: function() {
+        	onFocus: function(select) {
         		$eventResult.text('focus!');
         	},
-        	onBlur: function() {
+        	onBlur: function(select) {
         		$eventResult.text('blur!');
         	},
-        	onOptgroupClick: function(view) {
+        	onOptgroupClick: function(view, select) {
 				var values = $.map(view.children, function(child){
 					return child.value;
 				}).join(', ');
 				$eventResult.text('Optgroup ' + view.label + ' ' + 
 					(view.checked ? 'checked' : 'unchecked') + ': ' + values);
 			},
-			onClick: function(view) {
+			onClick: function(view, select) {
 				$eventResult.text(view.label + '(' + view.value + ') ' + 
 					(view.checked ? 'checked' : 'unchecked'));
 			}
@@ -1207,13 +1207,37 @@ styler: function(value) {
 
 Fires when the dropdown list is open.
 
+```javascript
+onOpen: function(select) {
+	/*
+	select: the Multiple Select object
+	*/
+}
+```
+
 #### onClose
 
-Fires when the dropdown list is close.
+Fires when the dropdown list is closed.
+
+```javascript
+onClose: function(select) {
+	/*
+	select: the Multiple Select object
+	*/
+}
+```
 
 #### onCheckAll
 
 Fires when all the options are checked by either clicking the "Select all" checkbox, or when the "checkall" method is programatically called.
+
+```javascript
+onCheckAll: function(select) {
+	/*
+	select: the Multiple Select object
+	*/
+}
+```
 
 #### onUncheckAll
 
@@ -1221,20 +1245,37 @@ Fires when all the options are checked by either clicking the "Select all" check
 
 Bind an event handler to the "focus".
 
+```javascript
+onFocus: function(select) {
+	/*
+	select: the Multiple Select object
+	*/
+}
+```
+
 #### onBlur
 
 Bind an event handler to the "blur"
+
+```javascript
+onBlur: function(select) {
+	/*
+	select: the Multiple Select object
+	*/
+}
+```
 
 #### onOptgroupClick
 
 Fires when a an optgroup label is clicked on. 
 
 ```javascript
-onOptgroupClick: function(view) {
+onOptgroupClick: function(view, select) {
 	/*
 	view.label: the text of the optgroup
 	view.checked: the checked of the optgroup
 	view.children: an array of the checkboxes (DOM elements) inside the optgroup
+	select: the Multiple Select object
 	*/
 }
 ```
@@ -1244,10 +1285,11 @@ onOptgroupClick: function(view) {
 Fires when a checkbox is checked or unchecked. 
 
 ```javascript
-onClick: function(view) {
+onClick: function(view, select) {
 	/*
 	view.label: the text of the checkbox item
 	view.checked: the checked of the checkbox item
+	select: the Multiple Select object
 	*/
 }
 ```

--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -194,8 +194,8 @@
                 });
             }
             this.$choice.off('click').on('click', toggleOpen)
-                .off('focus').on('focus', this.options.onFocus)
-                .off('blur').on('blur', this.options.onBlur);
+                .off('focus').on('focus', function () { this.options.onFocus(this); })
+                .off('blur').on('blur', function () { this.options.onBlur(this); });
 
             this.$parent.off('keydown').on('keydown', function (e) {
                 switch (e.which) {
@@ -229,7 +229,7 @@
                 } else { // when the filter option is true
                     that.$selectGroups.prop('checked', checked);
                     $items.prop('checked', checked);
-                    that.options[checked ? 'onCheckAll' : 'onUncheckAll']();
+                    that.options[checked ? 'onCheckAll' : 'onUncheckAll'](this);
                     that.update();
                 }
             });
@@ -245,7 +245,7 @@
                     label: $(this).parent().text(),
                     checked: checked,
                     children: $children.get()
-                });
+                }, this);
             });
             this.$selectItems.off('click').on('click', function () {
                 that.updateSelectAll();
@@ -255,7 +255,7 @@
                     label: $(this).parent().text(),
                     value: $(this).val(),
                     checked: $(this).prop('checked')
-                });
+                }, this);
 
                 if (that.options.single && that.options.isOpen && !that.options.keepOpen) {
                     that.close();
@@ -291,7 +291,7 @@
                 this.$searchInput.focus();
                 this.filter();
             }
-            this.options.onOpen();
+            this.options.onOpen(this);
         },
 
         close: function () {
@@ -305,7 +305,7 @@
                     'left': 'auto'
                 });
             }
-            this.options.onClose();
+            this.options.onClose(this);
         },
 
         update: function (isInit) {
@@ -356,7 +356,7 @@
             this.$selectAll.prop('checked', $items.length &&
                 $items.length === $items.filter(':checked').length);
             if (this.$selectAll.prop('checked')) {
-                this.options.onCheckAll();
+                this.options.onCheckAll(this);
             }
         },
 
@@ -433,7 +433,7 @@
             this.$selectGroups.prop('checked', true);
             this.$selectAll.prop('checked', true);
             this.update();
-            this.options.onCheckAll();
+            this.options.onCheckAll(this);
         },
 
         uncheckAll: function () {
@@ -441,17 +441,17 @@
             this.$selectGroups.prop('checked', false);
             this.$selectAll.prop('checked', false);
             this.update();
-            this.options.onUncheckAll();
+            this.options.onUncheckAll(this);
         },
 
         focus: function () {
             this.$choice.focus();
-            this.options.onFocus();
+            this.options.onFocus(this);
         },
 
         blur: function () {
             this.$choice.blur();
-            this.options.onBlur();
+            this.options.onBlur(this);
         },
 
         refresh: function () {

--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -55,6 +55,7 @@
         this.selectAllName = 'name="selectAll' + name + '"';
         this.selectGroupName = 'name="selectGroup' + name + '"';
         this.selectItemName = 'name="selectItem' + name + '"';
+        this.options.onAfterCreate(this);
     }
 
     MultipleSelect.prototype = {
@@ -584,6 +585,9 @@
             return false;
         },
         onClick: function () {
+            return false;
+        },
+        onAfterCreate: function () {
             return false;
         }
     };


### PR DESCRIPTION
Make it easier to track and use Multiple Selects from code by passing the object to the event callbacks, especially when there are many Multiple Selects on a single page. Also added `onAfterCreate` for the same reason.
