### PR TITLE
Added main property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,11 @@
   "authors": [
     "文翼 <wenzhixin2010@gmail.com>"
   ],
+  "main" : [
+    "multiple-select.css",
+    "multiple-select.png",
+    "jquery.multiple.select.js"
+  ],
   "description": "A jQuery plugin to select multiple elements with checkboxes",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The "main" property is meant to include the primary acting files necessary to use the package. A lot of build tools and tasks rely on it.