### PR TITLE
Fix Issue # 188 - Automatically set Group when all child was selected

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -416,6 +416,14 @@
             });
             this.$selectAll.prop('checked', this.$selectItems.length ===
                 this.$selectItems.filter(':checked').length);
+				
+            $.each(that.$selectGroups, function (i, val) {
+                var group = $(val).parent().attr('data-group'),
+                    $children = that.$selectItems.filter('[data-group="' + group + '"]');
+                $(val).prop('checked', $children.length &&
+                    $children.length === $children.filter(':checked').length);
+            });		
+			
             this.update();
         },
 


### PR DESCRIPTION
This improvement fix the problem described at Issue # 188, that when all child of a Group were set as true, the parent group was not set as true automatically.