### PR TITLE
Make setSelects Change Event Trigger Optional

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -307,7 +307,7 @@
             this.options.onClose();
         },
 
-        update: function (isInit) {
+        update: function (ignoreTrigger) {
             var selects = this.getSelects(),
                 $span = this.$choice.find('>span');
 
@@ -344,7 +344,7 @@
             });
 
             // trigger <select> change event
-            if (!isInit) {
+            if (!ignoreTrigger) {
                 this.$el.trigger('change');
             }
         },
@@ -416,7 +416,7 @@
             });
             this.$selectAll.prop('checked', this.$selectItems.length ===
                 this.$selectItems.filter(':checked').length);
-            this.update();
+            this.update(this.options.ignoreSetChangeEvent || false);
         },
 
         enable: function () {


### PR DESCRIPTION
The current setSelects method always triggers the 'change' event when run against a multiple select element. I am suggesting a configurable option to disable the 'change' event trigger when setSelects is called, forcing the developer to manually trigger it if designed. Outside this library, setting the value of an element through javascript does not trigger its change event and lets the developer decide if they want to raise this event. I am open to changing the name of this option too (I am not the best when it comes to thinking up names). I also changed the parameter name in update since its context is no longer bound to initialization. Overall, since this library currently does trigger the change event when setSelects is called, this proposal is to make it configurable for the developer to turn off this trigger so existing users see no changes and can optionally support this change.
