### PR TITLE
Prevents updateSelectAll() from calling options.onCheckAll() on init

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -338,7 +338,7 @@
             }
             if (this.options.addTitle)
                 $span.prop('title', this.getSelects('text'));
-                
+
             // set selects to select
             this.$el.val(this.getSelects());
 
@@ -359,7 +359,7 @@
             if (!Init) { $items = $items.filter(':visible'); }
             this.$selectAll.prop('checked', $items.length &&
                 $items.length === $items.filter(':checked').length);
-            if (this.$selectAll.prop('checked')) {
+            if (!Init && this.$selectAll.prop('checked')) {
                 this.options.onCheckAll();
             }
         },


### PR DESCRIPTION
The same way **update()** does not trigger the *change* event on _Init_ ( see sample from master below) , **updateSelectAll** should not call **options.onCheckAll()** on _init_.

```javascript
if (!isInit) {
    this.$el.trigger('change');
}
```