### PR TITLE
Fixes typo : ',' were used instead of '+'

### DIFF
--- a/jquery.multiple.select.js
+++ b/jquery.multiple.select.js
@@ -64,8 +64,8 @@
             var that = this;
             if (this.options.filter) {
                 this.$drop.append(
-                    '<div class="ms-search">',
-                    '<input type="text" autocomplete="off" autocorrect="off" autocapitilize="off" spellcheck="false">',
+                    '<div class="ms-search">' +
+                    '<input type="text" autocomplete="off" autocorrect="off" autocapitilize="off" spellcheck="false">' +
                     '</div>'
                 );
             }


### PR DESCRIPTION
There was a bug when using the **filter: on** option with Chrome . It was caused by the use of ',' instead of '+' .