### PR TITLE
Add selected class to "select all" option

### DIFF
--- a/multiple-select.js
+++ b/multiple-select.js
@@ -405,7 +405,7 @@
 
             // add selected class to selected li
             this.$drop.find('li').removeClass('selected');
-            this.$drop.find(sprintf('input[%s]:checked', this.selectItemName)).each(function () {
+            this.$drop.find('input:checked').each(function () {
                 $(this).parents('li').first().addClass('selected');
             });
 


### PR DESCRIPTION
Previously it would be applied to everything _except_ the "select all" option, making it impossible to style the "select all" option when it was selected.