### PR TITLE
Fix #264: Text from original options are no longer treated as html

### DIFF
--- a/multiple-select.js
+++ b/multiple-select.js
@@ -254,7 +254,7 @@
 
             if ($elm.is('option')) {
                 var value = $elm.val(),
-                    text = that.options.textTemplate($elm),
+                    html = $elm.html(),
                     selected = $elm.prop('selected'),
                     style = sprintf('style="%s"', this.options.styler(value)),
                     $el;
@@ -269,7 +269,7 @@
                         selected ? ' checked="checked"' : '',
                         disabled ? ' disabled="disabled"' : '',
                         sprintf(' data-group="%s"', group)),
-                    text,
+                    html,
                     '</label>',
                     '</li>'
                 ].join(''));


### PR DESCRIPTION
This updates optionToHtml so that it no longer reads the original as text and renders it as HTML.  The original option is now read and rendered as HTML, which consistently escapes and unescapes the contents.