### PR TITLE
Add information on current element to event(s)

### DIFF
--- a/multiple-select.js
+++ b/multiple-select.js
@@ -454,7 +454,7 @@
                     'left': 'auto'
                 });
             }
-            this.options.onClose();
+            this.options.onClose(this.$el);
         },
 
         animateMethod: function (method) {


### PR DESCRIPTION
Hey there,

when using multiple-select.js multiple times on the same page, it can be necessary to have access to the current HTML element for identification purposes.

Maybe this is also useful for other events and could be useful as an abstract implementation?!

Thanks
Gerrit 
