### PR TITLE
Single mode returning old and new values - fix

### DIFF
--- a/multiple-select.js
+++ b/multiple-select.js
@@ -382,6 +382,15 @@
                 });
             });
             this.$selectItems.off('click').on('click', function () {
+                if (that.options.single) {
+                    var clickedVal = $(this).val();
+                    that.$selectItems.filter(function() {
+                        return $(this).val() !== clickedVal;
+                    }).each(function() {
+                        $(this).prop('checked', false);
+                    });
+                }
+		    
                 that.updateSelectAll();
                 that.update();
                 that.updateOptGroupSelect();
@@ -396,15 +405,6 @@
                     that.close();
                 }
 
-                if (that.options.single) {
-                    var clickedVal = $(this).val();
-                    that.$selectItems.filter(function() {
-                        return $(this).val() !== clickedVal;
-                    }).each(function() {
-                        $(this).prop('checked', false);
-                    });
-                    that.update();
-                }
             });
         },
 


### PR DESCRIPTION
Original problem is demonstrated here https://jsfiddle.net/nop1984/08zx4koo/
Look into JS console. 
When single: true mode multipleSelect returns value twice: 1st is previous value and new selected value togather (both selected in SINGLE mode), 2nd is only new selected value
This 1st situation is unacceptable if you use multipleSelect for AJAX, you sending crappy data where 2 items are selected, 2nd sending containing is ignored because backend server already processing first.

This pull request solves this problem: change() is invoked for single mode after unneeded items are unmarked as checked.