### PR TITLE
Fixed outdated CSS syntax in linear-gradient

### DIFF
--- a/multiple-select.css
+++ b/multiple-select.css
@@ -126,7 +126,7 @@
     background: url('multiple-select.png') no-repeat 100% -22px, -moz-linear-gradient(center bottom, white 85%, #eeeeee 99%);
     background: url('multiple-select.png') no-repeat 100% -22px, -o-linear-gradient(bottom, white 85%, #eeeeee 99%);
     background: url('multiple-select.png') no-repeat 100% -22px, -ms-linear-gradient(top, #ffffff 85%, #eeeeee 99%);
-    background: url('multiple-select.png') no-repeat 100% -22px, linear-gradient(top, #ffffff 85%, #eeeeee 99%);
+    background: url('multiple-select.png') no-repeat 100% -22px, linear-gradient(to bottom, #ffffff 85%, #eeeeee 99%);
 }
 
 .ms-search, .ms-search input {


### PR DESCRIPTION
This outdated syntax cause some warnings with Autoprefixer.

```shell
 WARNING  Compiled with 1 warnings                                                                          09:19:03
 warning  in ./node_modules/multiple-select/multiple-select.css
Warning
(129:5) Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
```

- https://github.com/postcss/autoprefixer/issues/530
- https://developer.mozilla.org/es/docs/Web/CSS/linear-gradient