### PR TITLE
eslint-config-ash-nazg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,23 @@ module.exports = {
     'sourceType': 'module'
   },
   'extends': [
-    'eslint:recommended'
+    'ash-nazg/sauron-node'
+  ],
+  'overrides': [
+    {
+      'files': ['rollup*', 'tools/template.js'],
+      'env': {
+        'browser': false
+      }
+    },
+    {
+      'files': ['tools/template.js'],
+      'rules': {
+        'import/no-commonjs': 'off',
+        'import/unambiguous': 'off',
+        'node/no-unsupported-features/node-builtins': 'off'
+      }
+    }
   ],
   'rules': {
     'indent': ['error',
@@ -64,7 +80,11 @@ module.exports = {
     'no-useless-constructor': 'warn',
     'comma-dangle': ['error', 'never'],
     'no-param-reassign': 'off',
-    'space-before-function-paren': ["error", "always"]
+    'space-before-function-paren': ["error", "always"],
+    'quote-props': 'off',
+    'arrow-parens': 'off',
+    'require-unicode-regexp': 'off',
+    'max-len': 'off'
   },
   'globals': {
     '$': true,

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+tools
+docs

--- a/env.json
+++ b/env.json
@@ -1,0 +1,3 @@
+{
+  "NODE_ENV": "production"
+}

--- a/package.json
+++ b/package.json
@@ -55,8 +55,21 @@
   "dependencies": {},
   "devDependencies": {
     "@babel/preset-env": "^7.4.4",
+    "@mysticatea/eslint-plugin": "^10.0.2",
     "cssmin-cli": "^0.0.5",
     "eslint": "^5.16.0",
+    "eslint-config-ash-nazg": "^3.0.1",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-compat": "^3.1.1",
+    "eslint-plugin-eslint-comments": "^3.1.1",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-jsdoc": "^4.8.3",
+    "eslint-plugin-markdown": "^1.0.0",
+    "eslint-plugin-no-use-extend-native": "^0.4.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.1.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "eslint-plugin-unicorn": "^8.0.2",
     "getopts": "^2.2.3",
     "headr": "^0.0.4",
     "npm-run-all": "^4.1.5",
@@ -66,6 +79,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-inject": "^2.2.0",
     "rollup-plugin-node-resolve": "^4.2.3",
-    "sass": "^1.19.0"
+    "sass": "^1.19.0",
+    "typescript": "^3.4.5"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,8 @@ import minify from 'rollup-plugin-babel-minify'
 import inject from 'rollup-plugin-inject'
 // import vue from 'rollup-plugin-vue'
 
+import env from './env.json'
+
 const external = ['jquery']
 const globals = {
   jquery: 'jQuery'
@@ -23,14 +25,14 @@ const plugins = [
   })
 ]
 
-if (process.env.NODE_ENV === 'production') {
+if (env.NODE_ENV === 'production') {
   plugins.push(minify({
     comments: false
   }))
 }
 
 let out = 'dist/multiple-select.js'
-if (process.env.NODE_ENV === 'production') {
+if (env.NODE_ENV === 'production') {
   out = out.replace(/.js$/, '.min.js')
 }
 config.push({
@@ -46,7 +48,7 @@ config.push({
 })
 
 out = 'dist/multiple-select-es.js'
-if (process.env.NODE_ENV === 'production') {
+if (env.NODE_ENV === 'production') {
   out = out.replace(/.js$/, '.min.js')
 }
 config.push({

--- a/src/multiple-select.js
+++ b/src/multiple-select.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/unambiguous, unicorn/no-fn-reference-in-iterator */
+
 /**
  * @author zhixin wen <wenzhixin2010@gmail.com>
  * @version 1.2.3
@@ -24,6 +26,7 @@ const sprintf = (_str, ...args) => {
 
 const removeDiacritics = str => {
   const defaultDiacriticsRemovalMap = [
+    /* eslint-disable comma-spacing */
     {'base': 'A', 'letters': /[\u0041\u24B6\uFF21\u00C0\u00C1\u00C2\u1EA6\u1EA4\u1EAA\u1EA8\u00C3\u0100\u0102\u1EB0\u1EAE\u1EB4\u1EB2\u0226\u01E0\u00C4\u01DE\u1EA2\u00C5\u01FA\u01CD\u0200\u0202\u1EA0\u1EAC\u1EB6\u1E00\u0104\u023A\u2C6F]/g},
     {'base': 'AA','letters': /[\uA732]/g},
     {'base': 'AE','letters': /[\u00C6\u01FC\u01E2]/g},
@@ -108,6 +111,7 @@ const removeDiacritics = str => {
     {'base': 'x','letters': /[\u0078\u24E7\uFF58\u1E8B\u1E8D]/g},
     {'base': 'y','letters': /[\u0079\u24E8\uFF59\u1EF3\u00FD\u0177\u1EF9\u0233\u1E8F\u00FF\u1EF7\u1E99\u1EF5\u01B4\u024F\u1EFF]/g},
     {'base': 'z','letters': /[\u007A\u24E9\uFF5A\u017A\u1E91\u017C\u017E\u1E93\u1E95\u01B6\u0225\u0240\u2C6C\uA763]/g}
+    /* eslint-enable comma-spacing */
   ]
 
   for (let i = 0; i < defaultDiacriticsRemovalMap.length; i++) {
@@ -136,7 +140,8 @@ class MultipleSelect {
     this.$parent = $(sprintf(
       '<div class="ms-parent %s" %s/>',
       $el.attr('class') || '',
-      sprintf('title="%s"', $el.attr('title'))))
+      sprintf('title="%s"', $el.attr('title'))
+    ))
 
     // add placeholder to choice button
     this.options.placeholder = this.options.placeholder ||
@@ -179,8 +184,8 @@ class MultipleSelect {
         }
         if (
           ($(e.target)[0] === this.$drop[0] ||
-          $(e.target).parents('.ms-drop')[0] !== this.$drop[0] &&
-          e.target !== $el[0]) &&
+          ($(e.target).parents('.ms-drop')[0] !== this.$drop[0] &&
+          e.target !== $el[0])) &&
           this.options.isOpen
         ) {
           this.close()
@@ -200,8 +205,8 @@ class MultipleSelect {
       this.$drop.append([
         '<div class="ms-search">',
         '<input type="text" autocomplete="off" autocorrect="off" autocapitilize="off" spellcheck="false">',
-        '</div>'].join('')
-      )
+        '</div>'
+      ].join(''))
     }
 
     if (this.options.selectAll && !this.options.single) {
@@ -288,19 +293,22 @@ class MultipleSelect {
       $group.append([
         '<li class="group">',
         sprintf('<label class="optgroup %s" data-group="%s">', disabled ? 'disabled' : '', group),
-        this.options.hideOptgroupCheckboxes || this.options.single ? '' :
-          sprintf('<input type="checkbox" %s %s>',
+        this.options.hideOptgroupCheckboxes || this.options.single
+          ? ''
+          : sprintf('<input type="checkbox" %s %s>',
             this.selectGroupName, disabled ? 'disabled="disabled"' : ''),
         label,
         '</label>',
         '</li>'
       ].join(''))
 
-      $.each($elm.children(), (i, elm) => {
-        $group.append(this.optionToHtml(i, elm, group, disabled))
+      $.each($elm.children(), (j, elem) => {
+        $group.append(this.optionToHtml(j, elem, group, disabled))
       })
       return $group.html()
     }
+    // Append nothing
+    return undefined
   }
 
   events () {
@@ -334,7 +342,7 @@ class MultipleSelect {
       }
     })
 
-    this.$searchInput.off('keydown').on('keydown',e => {
+    this.$searchInput.off('keydown').on('keydown', e => {
       // Ensure shift-tab causes lost focus from filter as with clicking away
       if (e.keyCode === 9 && e.shiftKey) {
         this.close()
@@ -410,7 +418,6 @@ class MultipleSelect {
       if (this.options.single && this.options.isOpen && !this.options.keepOpen) {
         this.close()
       }
-
     })
   }
 
@@ -570,8 +577,8 @@ class MultipleSelect {
         html.push(text)
         if ($children.length > $selected.length) {
           const list = []
-          $selected.each((i, el) => {
-            list.push($(el).parent().text())
+          $selected.each((j, elem) => {
+            list.push($(elem).parent().text())
           })
           html.push(`: ${list.join(', ')}`)
         }

--- a/tools/template.js
+++ b/tools/template.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('fs').promises
 const getopts = require('getopts')
 
 const options = getopts(process.argv.slice(2), {
@@ -10,6 +10,10 @@ const options = getopts(process.argv.slice(2), {
   }
 })
 
+/**
+ * Logs help.
+ * @returns {void}
+ */
 function showHelp () {
   const baseCmd = 'node tools/template.js'
 
@@ -25,27 +29,33 @@ function showHelp () {
   `)
 }
 
-function run () {
+/**
+ * Perform document file writing.
+ * @returns {void}
+ */
+async function run () {
   if (options.help || Object.keys(options).length === 1) {
-    return showHelp()
+    showHelp()
+    return
   }
   if (!options.name) {
-    return console.error('You need to input -n, --name argv')
+    console.error('You need to input -n, --name argv')
+    return
   }
   if (!options.title) {
     options.title = options.name.split('-').join(' ')
   }
 
-  let content = fs.readFileSync(`${__dirname}/example.tpl`).toString()
+  let content = (await fs.readFile(`${__dirname}/example.tpl`)).toString()
   content = content.replace(/@title@/, options.title || '')
     .replace(/@desc@/, options.desc || '')
 
-  fs.writeFileSync(`${__dirname}/../docs/examples/${options.name}.html`, content)
+  await fs.writeFile(`${__dirname}/../docs/examples/${options.name}.html`, content)
   console.info(`${options.name}.html`)
 
-  let list = fs.readFileSync(`${__dirname}/../docs/_includes/example-list.md`).toString()
+  let list = (await fs.readFile(`${__dirname}/../docs/_includes/example-list.md`)).toString()
   list += `<li><a href="../examples#${options.name}.html">${options.title}</a></li>\n`
-  fs.writeFileSync(`${__dirname}/../docs/_includes/example-list.md`, list)
+  await fs.writeFile(`${__dirname}/../docs/_includes/example-list.md`, list)
 }
 
 run()


### PR DESCRIPTION
- Linting: Apply stricter `eslint-config-ash-nazg` rules, tweaking for Node.js files and allowin current styling (e.g., quoting props)
- Linting: Grouping to clarify operator precedence, not shadowing variables of same name in outer scope, explicit return when another return present, jsdoc, minor styling, no sync methods
- Add `tools` to .npmignore file (also avoids ESLint rule when a tools file requires a package only in `devDependencies`, not in `dependencies`)
- Avoid environmental variable (global dependency) in favor of `env.json` file (no-process-env rule)

See what you think of the stricter linting rules. I've mostly preserved your existing styles.