### PR TITLE
Avoid env dep

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,8 +91,7 @@ module.exports = {
     'quote-props': 'off',
     'arrow-parens': 'off',
     'require-unicode-regexp': 'off',
-    'max-len': 'off',
-    'no-process-env': 'off',
+    'max-len': 'off'
   },
   'globals': {
     '$': true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "eslint .",
     "js:build:base": "rollup -c",
-    "js:build:min": "rollup -c --environment PRODUCTION:true",
+    "js:build:min": "rollup -c --config-env PRODUCTION",
     "js:build:banner": "find dist -name '*.min.js' -exec headr {} -o {} --version --homepage --author --license \\;",
     "js:build": "run-s js:build:*",
     "css:build:scss": "find src -name '*.scss' | sed -e 'p;s/scss/css/' | xargs -n2 sass",
@@ -29,7 +29,7 @@
     "build": "run-s lint clean *:build",
     "docs": "bundle exec jekyll build",
     "docs-server": "bundle exec jekyll serve",
-    "js:dev": "rollup -c --environment DEV:true -w src/**/*.js",
+    "js:dev": "rollup -c --config-env DEV -w src/**/*.js",
     "css:dev": "sass --watch src/multiple-select.scss docs/assets/css/multiple-select.css",
     "dev": "npm run js:dev & npm run css:dev & npm run docs-server",
     "test": "testcafe chrome test/**/*.js --skip-js-errors"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,8 +5,17 @@ import minify from 'rollup-plugin-babel-minify'
 import inject from 'rollup-plugin-inject'
 // import vue from 'rollup-plugin-vue'
 
-const production = process.env.PRODUCTION === 'true'
-const dev = process.env.DEV === 'true'
+let found
+const env = process.argv.find((flag) => {
+  if (found) {
+    return true
+  }
+  found = flag === '--config-env'
+  return false
+})
+
+const production = env === 'PRODUCTION'
+const dev = env === 'DEV'
 
 const external = ['jquery']
 const globals = {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import inject from 'rollup-plugin-inject'
 // import vue from 'rollup-plugin-vue'
 
 let found
-const env = process.argv.find((flag) => {
+const env = process.argv.find(flag => {
   if (found) {
     return true
   }


### PR DESCRIPTION
- Switch to Rollup-approved `--config-` variables to avoid an environmental dependency

I think it is better to use the Rollup-approved `--config-` approach for passing in variables so that we will get the same behavior regardless of environment. If one is testing with a different env. variable, we may be confused with different behavior for the other. I think that is the rationale for the rule.

But of course, it's your call, so feel free to close if you prefer the env. variable.