### PR TITLE
Changing onClick so that the implementation can control if a click succeeds

### DIFF
--- a/src/MultipleSelect.js
+++ b/src/MultipleSelect.js
@@ -688,7 +688,7 @@ const defaults = {
     return false
   },
   onClick () {
-    return false
+    return true
   },
   onFilter () {
     return false

--- a/src/MultipleSelect.js
+++ b/src/MultipleSelect.js
@@ -299,6 +299,14 @@ class MultipleSelect {
     this.$selectItems.off('click').on('click', e => {
       const $this = $(e.currentTarget)
 
+      if(this.options.onClick({
+        label: $this.parent().text(),
+        value: $this.val(),
+        checked: !$this.prop('checked')
+      }) === false) {
+        return false;
+      }
+
       if (this.options.single) {
         const clickedVal = $(e.currentTarget).val()
         this.$selectItems.filter((i, el) => {
@@ -311,11 +319,6 @@ class MultipleSelect {
       this.updateSelectAll()
       this.update()
       this.updateOptGroupSelect()
-      this.options.onClick({
-        label: $this.parent().text(),
-        value: $this.val(),
-        checked: $this.prop('checked')
-      })
 
       if (this.options.single && this.options.isOpen && !this.options.keepOpen) {
         this.close()


### PR DESCRIPTION
By moving the onClick event call up and checking the return value, it enables users to prevent the box from being checked. This opens up new features, such as limiting the amount of boxes that can be checked, requested in #194 

```
var count = 0;
var max = 2;
$("select").multipleSelect({
  onClick: function(view) {
    if(!view.checked && count+1 > max) {
      return false;
    }
    if(!view.checked) count++;
    else count--;
});
```