### PR TITLE
Add lgtm.yml to exclude directories from lgtm.com linting

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,7 @@
+extraction:
+  javascript:
+    index:
+      filters:
+        - exclude: "dist"
+        - exclude: "site/website/pages/en/index.js"
+        - exclude: "site/website/pages/en/help-with-translations.js"


### PR DESCRIPTION
- Linting (LGTM): Add lgtm.yml to exclude directories from lgtm.com alerts: https://lgtm.com/projects/g/wenzhixin/multiple-select/?mode=list

I find this site very useful for identifying problems that even eslint won't identify, though in this case, they appear to be just some unimportant unused variables, so I've excluded the built `dist` directory and Facebook's code.

You can also set it up so that LGTM scans new PRs to make sure there are no new problems introduced.