### PR TITLE
Refresh children and value after component updated for vue3

### DIFF
--- a/src/vue/MultipleSelect.vue
+++ b/src/vue/MultipleSelect.vue
@@ -128,7 +128,7 @@ export default {
     }
   },
 
-  beforeUpdate () {
+  updated () {
     const children = this.$el.querySelectorAll('option,optgroup')
 
     if (


### PR DESCRIPTION
The children and value of compoent should be updated in `updated` vue component lifecycle hook, not in `beforeUpdate `.