### PR TITLE
Improve selector performance for large data case

### DIFF
--- a/src/MultipleSelect.js
+++ b/src/MultipleSelect.js
@@ -807,14 +807,24 @@ class MultipleSelect {
   }
 
   updateSelected () {
+    const inputMap = {}
+
+    this.$drop.find('input[data-key]').each((i, el) => {
+      const $el = $(el)
+
+      inputMap[$el.data('key')] = $el
+    })
     for (let i = this.updateDataStart; i < this.updateDataEnd; i++) {
       const row = this.updateData[i]
+      const $el = inputMap[row._key]
 
-      this.$drop.find(`input[data-key=${row._key}]`).prop('checked', row.selected)
-        .closest('li').toggleClass('selected', row.selected)
+      if ($el) {
+        $el.prop('checked', row.selected)
+        $el.closest('li').toggleClass('selected', row.selected)
+      }
     }
 
-    const noResult = this.data.filter(row => row.visible).length === 0
+    const noResult = !this.data.some(row => row.visible)
 
     if (this.$selectAll.length) {
       this.$selectAll.prop('checked', this.allSelected)

--- a/src/vue/MultipleSelect.vue
+++ b/src/vue/MultipleSelect.vue
@@ -129,11 +129,14 @@ export default {
   },
 
   updated () {
-    const children = this.$el.querySelectorAll('option,optgroup')
+    const children = [
+      ...this.$el.options,
+      ...this.$el.getElementsByTagName('optgroup')
+    ]
 
     if (
       children.length !== this.children.length ||
-      !Array.prototype.every.call(children, (item, index) => item === this.children[index])
+      children.some((item, index) => item !== this.children[index])
     ) {
       this._update()
       this.observer.disconnect()
@@ -264,11 +267,11 @@ export default {
     })(),
 
     _refresh () {
-      this.$el.querySelectorAll('option').forEach(el => {
+      for (const el of this.$el.options) {
         if (el.value) {
           $(el).data('value', el.value)
         }
-      })
+      }
     },
 
     refresh () {

--- a/src/vue/MultipleSelectVue2.vue
+++ b/src/vue/MultipleSelectVue2.vue
@@ -219,11 +219,11 @@ export default {
     })(),
 
     _refresh () {
-      this.$el.querySelectorAll('option').forEach(el => {
+      for (const el of this.$el.options) {
         if (el.value) {
           $(el).data('value', el.value)
         }
-      })
+      }
     },
 
     refresh () {


### PR DESCRIPTION
In the scenario of 10k+ data volume, the initialization time is reduced from 500ms to 100ms. 
It is mainly the updateSelected method. It is not a good idea to call the selector in the For loop with large data.