### PR TITLE
Fixed bootstrap theme checkbox focus state outline being clipped

### DIFF
--- a/src/themes/bootstrap.scss
+++ b/src/themes/bootstrap.scss
@@ -76,6 +76,8 @@
     border-radius: var(--ms-choice-border-radius);
 
     ul > li {
+      padding-left: 0;
+
       label {
         overflow: hidden;
         white-space: nowrap;
@@ -83,7 +85,7 @@
       }
 
       &:not(.hide-radio) label {
-        padding-left: calc(1.2em + 4px);
+        padding-left: calc(1.2em + 12px);
 
         input[type="radio"],
         input[type="checkbox"] {


### PR DESCRIPTION
- Before:
<img width="293" height="211" alt="image" src="https://github.com/user-attachments/assets/43ac7815-8007-429c-84cc-b054de0ce7d9" />

- After:
<img width="269" height="240" alt="image" src="https://github.com/user-attachments/assets/107511f2-0664-4b15-802a-d091f6dd7668" />
