### PR TITLE
Fix: Replace jQuery utilities with ES6+ in site templates

### DIFF
--- a/site/website/static/js/template.js
+++ b/site/website/static/js/template.js
@@ -97,18 +97,18 @@ function _beautifySource(data) {
   var scriptStart = lines.indexOf('<script>')
   var scriptEnd = lines.indexOf('</script>', scriptStart)
   var strings = lines.slice(scriptStart + 1, scriptEnd)
-  strings = $.map(strings, function (s) {
-    return $.trim(s)
+  strings = strings.map(function (s) {
+    return s.trim()
   })
   /* eslint-disable no-control-regex */
   var obj = eval('(' + strings.join('').replace(/[^\u0000-\u007E]/g, '')
     .replace(/^init\((.*)\)$/, '$1') + ')')
 
   var result = []
-  result = result.concat($.map(obj.links, _getLink))
+  result = result.concat(obj.links.map(_getLink))
   result.push('')
   result.push('<script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>')
-  result = result.concat($.map(obj.scripts, function (script) {
+  result = result.concat(obj.scripts.map(function (script) {
     return _getScript(script, true)
   }))
   lines = result.concat(lines.slice(scriptEnd + 1))
@@ -133,7 +133,11 @@ $(function () {
 
   $.ajax({
     type: 'GET',
-    url: url + '?' + $.param(query),
+    url: url + '?' + Object.keys(query).filter(function(key) {
+      return query[key] !== null && query[key] !== undefined
+    }).map(function(key) {
+      return encodeURIComponent(key) + '=' + encodeURIComponent(query[key])
+    }).join('&'),
     dataType: 'html',
     global: false,
     cache: true, // (warning: setting it to false will cause a timestamp and will call the request twice)
@@ -154,7 +158,7 @@ $(function () {
 })
 
 window.init = function (options_) {
-  var options = $.extend({
+  var options = Object.assign({
     title: '',
     desc: '',
     links: [],
@@ -169,7 +173,7 @@ window.init = function (options_) {
 
   $('.bd-title span').html(options.title)
   $('.bd-lead').html(options.desc)
-  $.each(options.links, function (i, file) {
+  options.links.forEach(function (file) {
     _link(file)
   })
   _scripts(options.scripts, options.callback)

--- a/site/website/static/templates/refresh.html
+++ b/site/website/static/templates/refresh.html
@@ -69,7 +69,7 @@ select {
       var $input = $('#refreshInput')
       var $selected = $('#refreshSelected')
       var $disabled = $('#refreshDisabled')
-      var value = $.trim($input.val())
+      var value = $input.val().trim()
       var $opt = $('<option />', {
         value: value,
         text: value


### PR DESCRIPTION
## 🤔 Type of Request

- [x] **Bug fix**
- [ ] New feature
- [ ] Improvement
- [ ] Documentation
- [ ] Other

## 🔗 Resolves an issue?

Fixes #677 - View source code not working after jQuery upgrade

## 📝 Description

This PR fixes the broken "View Source" functionality by replacing deprecated jQuery utility methods with ES6+ alternatives in the site templates.

After jQuery was upgraded to the latest version, `$.trim()` and other utility methods were removed, causing the view source feature to fail.

## 🎯 Changes

### 1. `site/website/static/js/template.js`
- `$.trim()` → `String.prototype.trim()`
- `$.map()` → `Array.prototype.map()`
- `$.each()` → `Array.prototype.forEach()`
- `$.extend()` → `Object.assign()`
- `$.param()` → Manual URL parameter encoding

### 2. `site/website/static/templates/refresh.html`
- `$.trim($input.val())` → `$input.val().trim()`

## ✅ Testing

- All lint checks pass
- Manual testing of view source functionality
- No breaking changes to existing functionality

## 📊 Files Modified

- `site/website/static/js/template.js` - 8 replacements
- `site/website/static/templates/refresh.html` - 1 replacement

---

Love multiple-select? Please consider supporting us:
👉 https://opencollective.com/multiple-select/donate