### PR TITLE
Fix filterOnly: 'Only this' button persists after clicking checkbox

### DIFF
--- a/src/MultipleSelect.js
+++ b/src/MultipleSelect.js
@@ -691,6 +691,10 @@ class MultipleSelect {
         data: option._data
       }))
 
+      if (this.options.filterOnly) {
+        $this.trigger('blur')
+      }
+
       close()
     })
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -44,11 +44,11 @@ const DEFAULTS = {
   filterAcceptOnEnter: false,
   filterByDataLength: undefined,
   filterSelectAll: true,
+  filterOnly: false,
   customFilter ({ text, label, search }) {
     return (label || text).includes(search)
   },
 
-  filterOnly: false,
   showClear: false,
   animate: undefined,
 


### PR DESCRIPTION
## Bug

When `filterOnly: true` is enabled, clicking a checkbox causes the "Only this" button to remain visible indefinitely on that row.

## Cause

After clicking a checkbox, it retains focus. The CSS `:focus-within` rule on `<li>` keeps the "Only this" button displayed even after the mouse moves away.

The `:focus-within` rule cannot be simply removed because it is needed to keep the button visible when the mouse moves from `<li>` onto the "Only this" button itself.

## Fix

Blur the checkbox after click when `filterOnly` is enabled, so `:focus-within` no longer keeps the button persistently shown.

## Files Changed

- `src/MultipleSelect.js` — blur checkbox after click when `filterOnly` is enabled
- `src/constants/index.js` — move `filterOnly` option to alphabetical position