### PR TITLE
Fix #687: Upgrade jQuery peer dependency to >=3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev": "yarn css:dev & yarn docs-server"
   },
   "peerDependencies": {
-    "jquery": "3"
+    "jquery": ">=3 <5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

- Upgrade jQuery peerDependencies from `"3"` to `">=3 <5"` to support both jQuery 3.x and jQuery 4.x
- No code changes required — jQuery Migrate script confirms no deprecation warnings with jQuery 4

Fixes #687