### PR TITLE
Fix deploy build failure caused by unescaped < in index.js

### DIFF
--- a/site/website/pages/en/index.js
+++ b/site/website/pages/en/index.js
@@ -104,7 +104,7 @@ class Index extends React.Component {
                 <MarkdownBlock>* **New:** Added `filterOnly` option to select only a single option.</MarkdownBlock>
                 <MarkdownBlock>* **New:** Added `maxWidth` option to limit the auto width.</MarkdownBlock>
                 <MarkdownBlock>* **New:** Auto refresh select width when the width attribute is `auto`.</MarkdownBlock>
-                <MarkdownBlock>* **Update:** Upgraded jQuery peer dependency to `>=3 <5` for jQuery 4 compatibility.</MarkdownBlock>
+                <MarkdownBlock>* **Update:** Upgraded jQuery peer dependency to `>=3,&lt;5` for jQuery 4 compatibility.</MarkdownBlock>
                 <MarkdownBlock>* **Update:** Fixed no-results padding in Bootstrap theme.</MarkdownBlock>
                 <MarkdownBlock></MarkdownBlock>
               </div>


### PR DESCRIPTION
## Description

The `Deploy Site` GitHub Actions workflow was failing on the `Build theme with node` step (`yarn docs`) with:

```
Error: Babylon parsing failure for file=.../site/website/pages/en/index.js: Unexpected token (107:86)
Note: Docusaurus v1 currently uses Babylon v6, and <> fragment syntax is not supported
```

The cause is the latest-release changelog line in `site/website/pages/en/index.js`:

```jsx
<MarkdownBlock>* **Update:** Upgraded jQuery peer dependency to `>=3 <5` for jQuery 4 compatibility.</MarkdownBlock>
```

Docusaurus v1 parses the JSX file with Babylon v6 **before** rendering Markdown, so the `<5` is misinterpreted as the start of a JSX tag, breaking the build.

## Solution

Escape the `<` as `&lt;` so it is no longer parsed as a JSX tag. The page still renders `>=3,<5` correctly.

```diff
-<MarkdownBlock>* **Update:** Upgraded jQuery peer dependency to `>=3 <5` for jQuery 4 compatibility.</MarkdownBlock>
+<MarkdownBlock>* **Update:** Upgraded jQuery peer dependency to `>=3,&lt;5` for jQuery 4 compatibility.</MarkdownBlock>
```
