### PR TITLE
Fix tabindex caching to prevent stale -1 value on re-init

### DIFF
--- a/src/MultipleSelect.js
+++ b/src/MultipleSelect.js
@@ -105,12 +105,21 @@ class MultipleSelect {
     this.options.placeholder = this.options.placeholder ||
       el.getAttribute('placeholder') || ''
 
-    this.tabIndex = el.getAttribute('tabindex')
-    let tabIndex = ''
-
-    if (this.tabIndex !== null) {
-      tabIndex = this.tabIndex && `tabindex="${this.tabIndex}"`
+    // Cache the original tabindex in jQuery data so we can restore it on
+    // destroy and transfer it to the choice button. The native <select> is
+    // hidden via `.ms-offscreen` (not display:none), so it stays in the tab
+    // order; we set it to -1 and move focus to the visible `.ms-choice`.
+    // Caching avoids re-reading the -1 on re-init (e.g. Vue refreshOptions).
+    if (this.$el.data('ms-tabindex') === undefined) {
+      this.$el.data('ms-tabindex', el.getAttribute('tabindex'))
     }
+    this.tabIndex = this.$el.data('ms-tabindex')
+
+    // Move the original tabindex to the choice button. Explicit empty-string
+    // check needed since "-1"/"0" are truthy.
+    const tabIndex = this.tabIndex !== null && this.tabIndex !== '' ?
+      ` tabindex="${this.tabIndex}"` : ''
+
     this.$el.attr('tabindex', -1)
 
     this.$choice = $(`
@@ -1321,9 +1330,14 @@ class MultipleSelect {
     }
     this.$el.before(this.$parent).removeClass('ms-offscreen')
 
+    // Restore the original tabindex and clear the cache so a later init
+    // re-reads it from the DOM.
     if (this.tabIndex !== null) {
       this.$el.attr('tabindex', this.tabIndex)
+    } else {
+      this.$el.removeAttr('tabindex')
     }
+    this.$el.removeData('ms-tabindex')
 
     this.$parent.remove()
 


### PR DESCRIPTION
## Problem

When the plugin is destroyed and re-initialized (e.g. Vue `refreshOptions`), the original `tabindex` of the `<select>` element is lost. During init, the native `<select>` gets `tabindex="-1"` to remove it from the tab order, but on re-init the code reads this `-1` back as the "original" value instead of the actual user-specified tabindex.

## Solution

- Cache the original `tabindex` in jQuery data (`ms-tabindex`) on first init, so re-inits read the cached value instead of the `-1` written to the DOM.
- On destroy, restore the original `tabindex` and clear the cache so a subsequent init re-reads from the DOM.
- Fix the `tabindex` attribute generation to properly handle `null` and empty-string values.

## Changes

- `src/MultipleSelect.js`: Cache original tabindex via `$.data()`, use cached value on re-init, restore and clear cache on destroy.
